### PR TITLE
fix: resolve requests package version conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==2.0.2
 aiohttp==3.9.5
 uWSGI==2.0.30
-requests==2.22.0
+requests>=2.26.0,<3.0.0
 urllib3==1.25.3
 gql[requests]==3.0.0
 Werkzeug==2.2.2


### PR DESCRIPTION
- Update requests from ==2.22.0 to >=2.26.0,<3.0.0
- Fix dependency conflict with gql[requests]==3.0.0
- Maintain compatibility with google-cloud packages