### PR TITLE
feat: filter low-engagement (likely bot) traffic from popular reports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # Google Analytics 4
 GA_RESOURCE_ID=311149968
 
+# Drop pages whose GA4 engagement rate is below this threshold (0.0–1.0).
+# Defaults to 0.3 (30%). Lower it to be more permissive, raise it to be stricter.
+MIN_ENGAGEMENT_RATE=0.3
+
 # Google Cloud Storage
 BUCKET=your-bucket-name
 GCS_PATH=path/to/reports/

--- a/ga_report.py
+++ b/ga_report.py
@@ -15,13 +15,6 @@ from gql_client import GraphQLClient
 from gql_queries import GET_POSTS_BY_SLUGS
 
 
-# Minimum GA4 engagement rate required for a page to qualify as a candidate.
-# Engaged session = > 10s, or has conversion, or 2+ pageviews. Crawler traffic
-# typically scores < 5%; real readers score 30%+. Configurable so the threshold
-# can be tuned without redeploy.
-MIN_ENGAGEMENT_RATE = float(os.environ.get('MIN_ENGAGEMENT_RATE', '0.3'))
-
-
 def format_post_data(post):
     data = post.copy()
     data.pop('exclusive', None)
@@ -41,10 +34,17 @@ async def get_article_async(response):
     graphql_client = GraphQLClient()
     gql_client = await graphql_client.get_authenticated_client()
 
+    # Engaged session in GA4 = > 10s on page, or has conversion, or 2+ pageviews.
+    # Crawler traffic typically scores < 5%; real readers score 30%+.
+    min_engagement_rate = float(os.environ.get('MIN_ENGAGEMENT_RATE', '0.3'))
+    # Resolve metric positions by name so reordering metrics in the request
+    # cannot silently swap which column is which.
+    metric_idx = {h.name: i for i, h in enumerate(response.metric_headers)}
+
     target_slugs = []
     id_bucket = set()
     exclusive = ["aboutus", "ad-sales", "adsales", "biography", "complaint", "faq", "press-self-regulation", "privacy", "standards", "webauthorization"]
-    
+
     for row in response.rows:
         uri = row.dimension_values[1].value
         id_match = re.match('/story/([\w-]+)', uri)
@@ -56,9 +56,9 @@ async def get_article_async(response):
         if not post_id or post_id[:3] == 'mm-' or post_id in exclusive:
             continue
 
-        engagement_rate = float(row.metric_values[1].value)
-        if engagement_rate < MIN_ENGAGEMENT_RATE:
-            views = row.metric_values[0].value
+        engagement_rate = float(row.metric_values[metric_idx['engagementRate']].value)
+        if engagement_rate < min_engagement_rate:
+            views = row.metric_values[metric_idx['screenPageViews']].value
             print(f"[bot-filtered] slug={post_id} views={views} engagement={engagement_rate:.1%}")
             continue
 

--- a/ga_report.py
+++ b/ga_report.py
@@ -15,6 +15,12 @@ from gql_client import GraphQLClient
 from gql_queries import GET_POSTS_BY_SLUGS
 
 
+# Minimum GA4 engagement rate required for a page to qualify as a candidate.
+# Engaged session = > 10s, or has conversion, or 2+ pageviews. Crawler traffic
+# typically scores < 5%; real readers score 30%+. Configurable so the threshold
+# can be tuned without redeploy.
+MIN_ENGAGEMENT_RATE = float(os.environ.get('MIN_ENGAGEMENT_RATE', '0.3'))
+
 
 def format_post_data(post):
     data = post.copy()
@@ -42,13 +48,22 @@ async def get_article_async(response):
     for row in response.rows:
         uri = row.dimension_values[1].value
         id_match = re.match('/story/([\w-]+)', uri)
-        if id_match:
-            post_id = id_match.group(1)
-            if post_id in id_bucket:
-                continue
-            if post_id and post_id[:3] != 'mm-' and post_id not in exclusive:
-                target_slugs.append(post_id)
-                id_bucket.add(post_id)
+        if not id_match:
+            continue
+        post_id = id_match.group(1)
+        if post_id in id_bucket:
+            continue
+        if not post_id or post_id[:3] == 'mm-' or post_id in exclusive:
+            continue
+
+        engagement_rate = float(row.metric_values[1].value)
+        if engagement_rate < MIN_ENGAGEMENT_RATE:
+            views = row.metric_values[0].value
+            print(f"[bot-filtered] slug={post_id} views={views} engagement={engagement_rate:.1%}")
+            continue
+
+        target_slugs.append(post_id)
+        id_bucket.add(post_id)
 
     if not target_slugs:
         return {'articles': [], 'yt': []}
@@ -104,7 +119,10 @@ async def popular_report(property_id):
     request = RunReportRequest(
         property=f"properties/{property_id}",
         dimensions=[Dimension(name="pageTitle"), Dimension(name="pagePath")],
-        metrics=[Metric(name="screenPageViews")],
+        metrics=[
+            Metric(name="screenPageViews"),
+            Metric(name="engagementRate"),
+        ],
         date_ranges=[DateRange(start_date=start_date, end_date="today")],
     )
 

--- a/test_filter.py
+++ b/test_filter.py
@@ -1,0 +1,167 @@
+"""Verify the engagement-rate filter in ga_report.get_article_async without
+hitting GA4 or the Keystone GraphQL endpoint.
+
+Run: python test_filter.py
+"""
+
+import asyncio
+import io
+import os
+import sys
+from contextlib import redirect_stdout
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def make_row(title, path, views, engagement_rate):
+    return SimpleNamespace(
+        dimension_values=[
+            SimpleNamespace(value=title),
+            SimpleNamespace(value=path),
+        ],
+        metric_values=[
+            SimpleNamespace(value=str(views)),
+            SimpleNamespace(value=str(engagement_rate)),
+        ],
+    )
+
+
+class FakeSession:
+    def __init__(self, posts):
+        self._posts = posts
+
+    async def execute(self, query, variable_values=None):
+        wanted = set(variable_values.get("slugs", []))
+        return {"posts": [p for p in self._posts if p["slug"] in wanted]}
+
+
+class FakeClient:
+    def __init__(self, posts):
+        self._posts = posts
+
+    async def __aenter__(self):
+        return FakeSession(self._posts)
+
+    async def __aexit__(self, *_):
+        return False
+
+
+class FakeGraphQLClient:
+    posts_in_db = []
+
+    def __init__(self):
+        pass
+
+    async def get_authenticated_client(self):
+        return FakeClient(self.posts_in_db)
+
+
+def make_post(slug, source="tv"):
+    return {
+        "id": slug,
+        "slug": slug,
+        "name": f"Title {slug}",
+        "publishTime": "2026-05-19T00:00:00.000Z",
+        "source": source,
+        "heroImage": {"resized": {"w480": "x.jpg", "w800": "y.jpg"}},
+        "exclusive": None,
+    }
+
+
+def run_with_threshold(threshold, rows, posts):
+    os.environ["MIN_ENGAGEMENT_RATE"] = str(threshold)
+    for module_name in ("ga_report",):
+        sys.modules.pop(module_name, None)
+    import ga_report
+
+    FakeGraphQLClient.posts_in_db = posts
+    response = SimpleNamespace(rows=rows)
+
+    captured = io.StringIO()
+    with patch.object(ga_report, "GraphQLClient", FakeGraphQLClient), redirect_stdout(captured):
+        result = asyncio.run(ga_report.get_article_async(response))
+    return result, captured.getvalue()
+
+
+def test_filters_low_engagement():
+    rows = [
+        # crawler-pattern: high views, near-zero engagement
+        make_row("劉邦友血案", "/story/20220208sot12021", 250046, 0.016),
+        make_row("台積電之歌", "/story/20250620sot18012", 250046, 0.009),
+        # real reader behavior
+        make_row("520育嬰假", "/story/20260519nm009", 51048, 0.55),
+        make_row("淡江大橋", "/story/20260516nm010", 30000, 0.42),
+    ]
+    posts = [make_post(s) for s in (
+        "20220208sot12021", "20250620sot18012", "20260519nm009", "20260516nm010",
+    )]
+    result, stdout = run_with_threshold(0.3, rows, posts)
+
+    slugs_kept = {a["slug"] for a in result["articles"]}
+    assert slugs_kept == {"20260519nm009", "20260516nm010"}, slugs_kept
+    assert "[bot-filtered] slug=20220208sot12021" in stdout
+    assert "[bot-filtered] slug=20250620sot18012" in stdout
+    assert "engagement=1.6%" in stdout
+    assert "engagement=0.9%" in stdout
+    print("PASS test_filters_low_engagement")
+
+
+def test_existing_filters_preserved():
+    rows = [
+        # mm- prefix: existing exclusion still applies
+        make_row("mm article", "/story/mm-20260318edi033", 126740, 0.72),
+        # slug blacklist
+        make_row("about us", "/story/aboutus", 1000, 0.9),
+        # not a /story/ URL
+        make_row("category page", "/category/pol", 66261, 0.18),
+        # duplicate slug from two rows (different titles)
+        make_row("dup A", "/story/20260518nm010", 50000, 0.6),
+        make_row("dup B", "/story/20260518nm010", 40000, 0.7),
+        # one legitimate yt-source article that should pass
+        make_row("yt one", "/story/20260518sot1729001", 30000, 0.5),
+    ]
+    posts = [
+        make_post("20260518nm010", source="tv"),
+        make_post("20260518sot1729001", source="yt"),
+    ]
+    result, stdout = run_with_threshold(0.3, rows, posts)
+
+    slugs_kept = [a["slug"] for a in result["articles"]]
+    assert slugs_kept == ["20260518nm010", "20260518sot1729001"], slugs_kept
+    yt_slugs = [a["slug"] for a in result["yt"]]
+    assert yt_slugs == ["20260518sot1729001"], yt_slugs
+    assert "mm-" not in stdout  # mm- exclusion happens BEFORE engagement check, no log
+    print("PASS test_existing_filters_preserved")
+
+
+def test_threshold_zero_disables_filter():
+    rows = [
+        make_row("low engagement", "/story/20220208sot12021", 250046, 0.016),
+    ]
+    posts = [make_post("20220208sot12021")]
+    result, stdout = run_with_threshold(0.0, rows, posts)
+
+    slugs_kept = {a["slug"] for a in result["articles"]}
+    assert slugs_kept == {"20220208sot12021"}, slugs_kept
+    assert "[bot-filtered]" not in stdout
+    print("PASS test_threshold_zero_disables_filter")
+
+
+def test_heroimage_format():
+    rows = [
+        make_row("with image", "/story/abc001", 1000, 0.5),
+    ]
+    posts = [make_post("abc001")]
+    result, _ = run_with_threshold(0.3, rows, posts)
+
+    image = result["articles"][0]["heroImage"]
+    assert image == {"w480": "x.jpg", "w800": "y.jpg"}, image
+    print("PASS test_heroimage_format")
+
+
+if __name__ == "__main__":
+    test_filters_low_engagement()
+    test_existing_filters_preserved()
+    test_threshold_zero_disables_filter()
+    test_heroimage_format()
+    print("\nAll tests passed.")

--- a/test_filter.py
+++ b/test_filter.py
@@ -7,10 +7,20 @@ Run: python test_filter.py
 import asyncio
 import io
 import os
-import sys
 from contextlib import redirect_stdout
 from types import SimpleNamespace
 from unittest.mock import patch
+
+import ga_report
+
+# Production order is screenPageViews, engagementRate. The test deliberately
+# stores rows in a different physical order from the headers it advertises
+# (engagementRate first, screenPageViews second) so that any reintroduction of
+# hardcoded index access would surface as a test failure.
+METRIC_HEADERS = [
+    SimpleNamespace(name="engagementRate"),
+    SimpleNamespace(name="screenPageViews"),
+]
 
 
 def make_row(title, path, views, engagement_rate):
@@ -20,8 +30,8 @@ def make_row(title, path, views, engagement_rate):
             SimpleNamespace(value=path),
         ],
         metric_values=[
-            SimpleNamespace(value=str(views)),
             SimpleNamespace(value=str(engagement_rate)),
+            SimpleNamespace(value=str(views)),
         ],
     )
 
@@ -70,12 +80,8 @@ def make_post(slug, source="tv"):
 
 def run_with_threshold(threshold, rows, posts):
     os.environ["MIN_ENGAGEMENT_RATE"] = str(threshold)
-    for module_name in ("ga_report",):
-        sys.modules.pop(module_name, None)
-    import ga_report
-
     FakeGraphQLClient.posts_in_db = posts
-    response = SimpleNamespace(rows=rows)
+    response = SimpleNamespace(rows=rows, metric_headers=METRIC_HEADERS)
 
     captured = io.StringIO()
     with patch.object(ga_report, "GraphQLClient", FakeGraphQLClient), redirect_stdout(captured):


### PR DESCRIPTION
## Problem

`popularlist.json` (and the YouTube-source subset `popular-videonews-list.json`) has been including articles with abnormally low engagement that point to automated/bot traffic rather than real readers. The following 4-year-old story was ranked **#1** in today's prod popular list with **250k views but only 1.6% engagement rate** — a textbook crawler pattern:

- `20220208sot12021` (2022-02-08 「劉邦友血案新曙光？」) — 250,046 views, **1.6%** engagement
- `20250620sot18012` (2025-06-20 「台積電之歌」) — 250,046 views, **0.9%** engagement
- `20250816rep001` (2025-08-16) — 230,953 views, **0.9%** engagement

For reference, normal articles with UTM-driven real readers score 50–80% engagement; category pages score ~10–20%.

A page's engaged session in GA4 requires either >10s on page, a conversion event, OR 2+ pageviews — none of which bots typically trigger. Engagement rate is therefore a strong signal to separate human from automated traffic.

## Scope

This service generates **two** GCS outputs from a single GA4 call in `popular_report()`:

| Output | Bucket path (prod) | Consumer |
|---|---|---|
| `popularlist.json` | `v2-static-mnews-tw-prod/json/popularlist.json` | mnews.tw 鏡電視 (Tabris/mirror-tv-next) — homepage / story aside popular list |
| `popular-videonews-list.json` | `v2-static-mnews-tw-prod/json/popular-videonews-list.json` | mnews.tw — popular videos section (subset of articles with `source == "yt"`) |

Both come from the same `target_slugs` list inside `get_article_async`, so the engagement filter introduced here covers both files with no additional work.

## Change

1. Add `engagementRate` as a second metric to the GA4 `RunReportRequest`.
2. In `get_article_async`, drop any row whose `engagementRate < MIN_ENGAGEMENT_RATE` (default `0.3`, configurable via env var) before slug extraction. This affects both output files because `popular_video` is built from the same already-filtered slug list.
3. Log each dropped row as `[bot-filtered] slug=... views=... engagement=...%` for diagnostics.
4. Refactor the slug-extraction `if` chain into early-return style for readability (no behavior change to existing exclusion rules).
5. Add `MIN_ENGAGEMENT_RATE` to `.env.example`.
6. Add `test_filter.py` with four unit tests covering: low-engagement filtering, preservation of existing `mm-` / blacklist / dedup rules, threshold=0 fallback, and `heroImage` output format.
7. **Review fix (commit `9fd613c`):**
   - Move env read from module scope into `get_article_async` so tests no longer need module reimport gymnastics.
   - Resolve metric column positions via `response.metric_headers` by name instead of hardcoded indices, so reordering the `RunReportRequest` metrics list cannot silently swap views and engagement values. The test fixture deliberately advertises headers in reverse order to guard against any reintroduction of positional access.

## Verification

**Unit tests (`python test_filter.py`):** 4/4 pass.

**Local dry run against prod GA4 (read-only, output redirected to local files, no GCS write):**

| Article | Before (no filter) | After (MIN=0.3) |
|---|---|---|
| `20220208sot12021` (2022) | `popularlist` #1 | **removed from both files** |
| `20250620sot18012` (2025-06) | `popularlist` #16 (also `source=yt`, in videonews) | **removed from both files** |
| 99 long-tail 1-view bot URLs | (each present) | **all removed** |
| `20260517sot1842001` (today's news) | `popularlist` #2, `videonews` #1 | `popularlist` #1, `videonews` #1 |
| Real-news items (`20260518nm*`) | various | unchanged ranking ±1 |
| Genuinely-evergreen old items (e.g. `20240312nm016`) | present | retained (engagement ≥ 30%) |

Output sizes after filtering: `popularlist.json` 30 items, `popular-videonews-list.json` 11 items — matches expected (top 30 articles overall, top 10 yt-source subset, both with bot URLs removed).

The filter correctly removes the targeted bot URLs while leaving real and evergreen content in place. The default `0.3` is conservative — actual bot traffic measured at 0.4–1.6%, so there is plenty of headroom before the threshold needs revisiting.

## Rollout / Rollback

- Default `0.3` (30%) is intentionally conservative; tune via env var without redeploy.
- **Rollback:** set `MIN_ENGAGEMENT_RATE=0` in the Cloud Run env to disable filtering entirely (applies to both output files at once).
- Recommended: deploy to staging first, observe `[bot-filtered]` log volume in Cloud Logging for one day, then promote to prod.

## Not in this PR (suggested follow-ups)

- Prod admin password is currently stored as a plain Cloud Run env var; should migrate to Secret Manager.
- Top-30 articles still include some 2024–2025 articles that pass the 30% threshold — could be either genuinely evergreen content or smarter crawlers; revisit after observing live behavior.
- `popular.json` / `404_popular.json` for 鏡週刊 (Adam / mirror-media-next, `mirrormedia.mg`) is produced by a separate service (not this repo); evaluate whether the same engagement filter is needed there.